### PR TITLE
bootstrap and retry_join fixed. Hardcoded path to metadata removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 
 This Docker image will use confd with Rancher backend, to will parse the template and replace some values from the metadata of Ranchercontainers, the values will include the following:
 
-- ca certificate.
+- ca certificate
 - consul certificates and keys.
-- turning bootstrap on/off, only if the container is the first container in the cluster.
+- bootstrap_expect - numbers of nodes to bootstrap. should be 3 or 5
 - gossip key.
+
+If acl.enabled is true, acl.master_token and acl.agent_token should be provided. After cluster is up, you must add rules for agent token:
+
+# Create agent.json with the following content
+{
+  "ID":"### YOUR AGENT TOKEN ###",
+  "Name": "agent",
+  "Type": "client",
+  "Rules": "node \"\" {policy = \"write\"} service \"\" {policy = \"write\"}"
+}
+
+# Upload it to consul. Replace consul host and master_token with yours.
+curl -X PUT -d @agent.json http://consul/v1/acl/create\?token\=<master_token_here>

--- a/conf.d/ca.crt.toml
+++ b/conf.d/ca.crt.toml
@@ -1,5 +1,5 @@
 [template]
-prefix = "/services/consul/metadata"
+prefix = "/self/service/metadata/"
 src = "ca.crt.tmpl"
 dest = "/opt/rancher/ssl/ca.crt"
 owner = "root"

--- a/conf.d/consul.crt.toml
+++ b/conf.d/consul.crt.toml
@@ -4,8 +4,8 @@ dest = "/opt/rancher/ssl/consul.crt"
 owner = "root"
 mode = "0644"
 keys = [
-  "/services/consul/metadata/consul1.crt",
-  "/services/consul/metadata/consul2.crt",
-  "/services/consul/metadata/consul3.crt",
+  "/self/service/metadata/consul1.crt",
+  "/self/service/metadata/consul2.crt",
+  "/self/service/metadata/consul3.crt",
   "/self/container/service_index",
   ]

--- a/conf.d/consul.key.toml
+++ b/conf.d/consul.key.toml
@@ -4,8 +4,8 @@ dest = "/opt/rancher/ssl/consul.key"
 owner = "root"
 mode = "0644"
 keys = [
-  "/services/consul/metadata/consul1.key",
-  "/services/consul/metadata/consul2.key",
-  "/services/consul/metadata/consul3.key",
+  "/self/service/metadata/consul1.key",
+  "/self/service/metadata/consul2.key",
+  "/self/service/metadata/consul3.key",
   "/self/container/service_index",
 ]

--- a/conf.d/server.json.toml
+++ b/conf.d/server.json.toml
@@ -4,15 +4,19 @@ dest = "/opt/rancher/config/server.json"
 owner = "root"
 mode = "0644"
 keys = [
-  "/self/service/containers",
+  "/self/service/name",
+  "/self/stack/name",
   "/containers",
   "self/container/name",
   "/self/container/primary_ip",
-  "/services/consul/metadata/enc.key",
-  "/services/consul/metadata/acl.enabled",
-  "/services/consul/metadata/acl.default_policy",
-  "/services/consul/metadata/acl.down_policy",
-  "/services/consul/metadata/acl.master_token",
-  "/services/consul/metadata/ui.enabled",
+  "/self/service/metadata/enc.key",
+  "/self/service/metadata/acl.enabled",
+  "/self/service/metadata/acl.default_policy",
+  "/self/service/metadata/acl.down_policy",
+  "/self/service/metadata/acl.master_token",
+  "/self/service/metadata/acl.agent_token",
+  "/self/service/metadata/ui.enabled",
+  "/self/service/metadata/bootstrap_expect",
   "/self/container/service_index",
+  "/self/container/uuid"
 ]

--- a/templates/consul.crt.tmpl
+++ b/templates/consul.crt.tmpl
@@ -1,1 +1,1 @@
-{{ $containerID := (getv "/self/container/service_index") }}{{ getv (printf "/services/consul/metadata/consul%s.crt" $containerID) }}
+{{ $containerID := (getv "/self/container/service_index") }}{{ getv (printf "/self/service/metadata/consul%s.crt" $containerID) }}

--- a/templates/consul.key.tmpl
+++ b/templates/consul.key.tmpl
@@ -1,1 +1,1 @@
-{{ $containerID := getv "/self/container/service_index" }}{{ getv (printf "/services/consul/metadata/consul%s.key" $containerID) }}
+{{ $containerID := getv "/self/container/service_index" }}{{ getv (printf "/self/service/metadata/consul%s.key" $containerID) }}

--- a/templates/server.json.tmpl
+++ b/templates/server.json.tmpl
@@ -1,25 +1,26 @@
 {
-    {{ if (eq (getv "/self/container/service_index") "1") }}"bootstrap": true,{{else}}
-    "retry_join": [{{ $containerName := getv "/self/service/containers/0"}}"{{getv (printf "/containers/%s/primary_ip" $containerName)}}"],
-    "bootstrap": false,{{end}}
+    "retry_join": ["{{getv "/self/service/name"}}.{{getv "/self/stack/name"}}"],
+    "bootstrap_expect": {{getv "/self/service/metadata/bootstrap_expect"}},
     "server": true,
     "datacenter": "dc1",
     "advertise_addr": "{{getv "/self/container/primary_ip"}}",
     "bind_addr": "{{getv "/self/container/primary_ip"}}",
     "client_addr": "{{getv "/self/container/primary_ip"}}",
     "data_dir": "/var/consul",
-    "encrypt": "{{getv "/services/consul/metadata/enc.key"}}",
+    "encrypt": "{{getv "/self/service/metadata/enc.key"}}",
+    "disable_host_node_id": true,
     "ca_file": "/opt/rancher/ssl/ca.crt",
     "cert_file": "/opt/rancher/ssl/consul.crt",
     "key_file": "/opt/rancher/ssl/consul.key",
     "verify_incoming": true,
     "verify_outgoing": true,
-    {{ if (eq (getv "/services/consul/metadata/acl.enabled") "true") }}
+    {{ if (eq (getv "/self/service/metadata/acl.enabled") "true") }}
     "acl_datacenter": "dc1",
-    "acl_default_policy": "{{getv "/services/consul/metadata/acl.default_policy"}}",
-    "acl_down_policy": "{{getv "/services/consul/metadata/acl.down_policy"}}",
-    "acl_master_token": "{{getv "/services/consul/metadata/acl.master_token"}}",
+    "acl_default_policy": "{{getv "/self/service/metadata/acl.default_policy"}}",
+    "acl_down_policy": "{{getv "/self/service/metadata/acl.down_policy"}}",
+    "acl_master_token": "{{getv "/self/service/metadata/acl.master_token"}}",
+    "acl_agent_token": "{{getv "/self/service/metadata/acl.agent_token"}}",
     {{ end }}
-    "ui": {{getv "/services/consul/metadata/ui.enabled"}},
+    "ui": {{getv "/self/service/metadata/ui.enabled"}},
     "log_level": "INFO"
 }


### PR DESCRIPTION
This change uses "service.stack" address to bootstrap cluster. In previous setup cluster will have split-brain if first node breaks.

Also adjustments to rancher catalog needed for new parameters.